### PR TITLE
Update dbus to v1.16.0

### DIFF
--- a/org.sabnzbd.sabnzbd.yaml
+++ b/org.sabnzbd.sabnzbd.yaml
@@ -32,12 +32,12 @@ cleanup:
 modules:
   - pypi-dependencies.json
   - name: dbus-run-session
-    buildsystem: autotools
+    buildsystem: cmake
     cleanup: ["*"]
     sources:
       - type: archive
-        url: https://gitlab.freedesktop.org/dbus/dbus/-/archive/dbus-1.15.8/dbus-dbus-1.15.8.tar.gz
-        sha256: 3ae23cd28b96beac175eab0798d65c8e21e9fcf57132d840c170aaa7b21cd818
+        url: https://gitlab.freedesktop.org/dbus/dbus/-/archive/dbus-1.16.0/dbus-dbus-1.16.0.tar.gz
+        sha256: d2ca9d958c830e762ba70aea8e6b5c29fa7b58d0fee8ddd9bb5a00f35106ab57
         x-checker-data:
           type: anitya
           project-id: 5356


### PR DESCRIPTION
Utilize cmake instead of autotools, as only meson and cmake are supported as of dbus v1.16.0

https://gitlab.freedesktop.org/dbus/dbus/-/blob/8ca823d38f4d028b7844f204b1787bbc03b3a0f4/INSTALL#L7-10