### PR TITLE
add option to [skip auto-update]

### DIFF
--- a/.github/workflows/auto-update.yaml
+++ b/.github/workflows/auto-update.yaml
@@ -1,6 +1,6 @@
 # This workflow refreshes the pypi and cargo dependencies, and updates requirements.txt whenever
-# sabnzbd itself gets a version bump. To skip the workflow, include '[skip actions]' in any of the
-# commit messages in your push or the HEAD commit of your PR.
+# sabnzbd itself gets a version bump. To skip the workflow, include "[skip auto-update]" in any of the
+# commit messages in your push or the HEAD commit of your PR. (similar to github's "[skip actions]")
 name: auto-update
 
 on:
@@ -24,6 +24,7 @@ jobs:
     # Don't run on forks (pointless) or pull requests originating from forks (no commit access), and
     # prevent manual runs directly on the master branch (circumventing the usual flatpak test build)
     if: >
+      !contains(github.event.head_commit.message, '[skip auto-update]') &&
       github.repository == 'flathub/org.sabnzbd.sabnzbd' && (
         ( github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name ) ||
         ( github.event_name == 'workflow_dispatch' && github.ref_name != 'master' )


### PR DESCRIPTION
Github's `[skip actions]` also affects the flathub test build, which appears to be mandatory nowadays to commit to the master branch. Skipping the auto-update allows for manual intervention in case the automation gets it wrong.