### PR TITLE
switch removal of scriptlets to find cmd

### DIFF
--- a/org.sabnzbd.sabnzbd.yaml
+++ b/org.sabnzbd.sabnzbd.yaml
@@ -40,27 +40,9 @@ cleanup:
   - /bin/tools
   - /bin/README.mkd
   - /bin/*.txt
+cleanup-commands:
   # Scriptlets installed by pip, not needed by SABnzbd
-  - /bin/apprise
-  - /bin/calc-prorate
-  - /bin/chardetect
-  - /bin/cheetah
-  - /bin/cheetah-analyze
-  - /bin/cheetah-compile
-  - /bin/cheroot
-  - /bin/cherryd
-  - /bin/guessit
-  - /bin/httpx
-  - /bin/idna
-  - /bin/markdown-it
-  - /bin/maturin
-  - /bin/normalizer
-  - /bin/puccinialize
-  - /bin/pygmentize
-  - /bin/setuptools-scm
-  - /bin/tqdm
-  - /bin/typer
-  - /bin/vcs-versioning
+  - find ${FLATPAK_DEST}/bin -maxdepth 1 -type f -executable -not -name 'SABnzbd.py' -not -name '7zz' -not -name 'par2' -not -name 'unrar' -ls -delete
 modules:
   # Assorted pypi dependencies, generated from requirements-*.txt
   - pypi-dependencies-flatpak.json

--- a/pypi-dependencies-flatpak.json
+++ b/pypi-dependencies-flatpak.json
@@ -50,8 +50,8 @@
             "sources": [
                 {
                     "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/16/7f/d1b0c65b267a1463d752b324f11d3470e30889daefc4b9ec83029bfa30b5/meson_python-0.19.0-py3-none-any.whl",
-                    "sha256": "67b5906c37404396d23c195e12c8825506074460d4a2e7083266b845d14f0298"
+                    "url": "https://files.pythonhosted.org/packages/90/ad/77f9483e180cabab2772ac222aedd3dfab858e60d992f40414a3f08e7494/meson_python-0.20.0-py3-none-any.whl",
+                    "sha256": "6a744cf0c09e76ecbdc58cfa374b48c8902dac1b74479628238634efbf36aec9"
                 },
                 {
                     "type": "file",

--- a/pypi-dependencies-orjson.json
+++ b/pypi-dependencies-orjson.json
@@ -17,8 +17,8 @@
         },
         {
             "type": "file",
-            "url": "https://files.pythonhosted.org/packages/81/47/dd9a212ef6e343a6857485ffe25bba537304f1913bdbed446a23f7f592e1/filelock-3.29.0-py3-none-any.whl",
-            "sha256": "96f5f6344709aa1572bbf631c640e4ebeeb519e08da902c39a001882f30ac258"
+            "url": "https://files.pythonhosted.org/packages/81/8f/b61d427c4f49a8bdadc93f4e7e74df8a6df6f77ee6e26bf0df53d3925363/filelock-3.29.3-py3-none-any.whl",
+            "sha256": "e58333029cc9b925f39aad59b1d8f0a1ad836af4e60d7217f4a4dba87461261d"
         },
         {
             "type": "file",
@@ -37,8 +37,8 @@
         },
         {
             "type": "file",
-            "url": "https://files.pythonhosted.org/packages/de/a7/f76514cc40ad6234098ecdebda08732d75964776c51a42845b7da10649e2/idna-3.17-py3-none-any.whl",
-            "sha256": "466e48829084efe2548012b855df21540b96f2e20e51bd124c851536556a592c"
+            "url": "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl",
+            "sha256": "7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2"
         },
         {
             "type": "file",
@@ -52,8 +52,8 @@
         },
         {
             "type": "file",
-            "url": "https://files.pythonhosted.org/packages/16/e1/3079a9ff9b8e11b846c6ac5c8b5bfb7ff225eee721825310c91b3b50304f/tqdm-4.67.3-py3-none-any.whl",
-            "sha256": "ee1e4c0e59148062281c49d80b25b67771a127c85fc9676d3be5f243206826bf"
+            "url": "https://files.pythonhosted.org/packages/eb/75/1a0392bcc21c44dcdf87b3cf2d137e7829be2c083a1e38d44efca3d57a16/tqdm-4.68.2-py3-none-any.whl",
+            "sha256": "d4240441fb5353290b87d6a85968c9decc131a99b8c7faa28269d829de669ede"
         }
     ]
 }

--- a/pypi-dependencies.json
+++ b/pypi-dependencies.json
@@ -32,8 +32,8 @@
                 },
                 {
                     "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/de/a7/f76514cc40ad6234098ecdebda08732d75964776c51a42845b7da10649e2/idna-3.17-py3-none-any.whl",
-                    "sha256": "466e48829084efe2548012b855df21540b96f2e20e51bd124c851536556a592c"
+                    "url": "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl",
+                    "sha256": "7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2"
                 },
                 {
                     "type": "file",
@@ -208,8 +208,8 @@
                 },
                 {
                     "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/f0/6d/5a525c69df4a90892135e5d490b00e9e46402491f3416d4395fcb0d0201e/typer-0.26.4-py3-none-any.whl",
-                    "sha256": "11bfd7b43557137e373c2b10f6967a555f9678a61ed72c808968b011d95534d6"
+                    "url": "https://files.pythonhosted.org/packages/24/25/2201973529af2c954de0bb725323c3aaed6d7f0ceee8f550dec9185df013/typer-0.26.7-py3-none-any.whl",
+                    "sha256": "5c87cfbc5d34491c5346ebf49c23e18d56ccb863268d3a8d592b26087c2f5e58"
                 },
                 {
                     "type": "file",
@@ -416,8 +416,8 @@
                 },
                 {
                     "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/f0/6d/5a525c69df4a90892135e5d490b00e9e46402491f3416d4395fcb0d0201e/typer-0.26.4-py3-none-any.whl",
-                    "sha256": "11bfd7b43557137e373c2b10f6967a555f9678a61ed72c808968b011d95534d6"
+                    "url": "https://files.pythonhosted.org/packages/24/25/2201973529af2c954de0bb725323c3aaed6d7f0ceee8f550dec9185df013/typer-0.26.7-py3-none-any.whl",
+                    "sha256": "5c87cfbc5d34491c5346ebf49c23e18d56ccb863268d3a8d592b26087c2f5e58"
                 },
                 {
                     "type": "file",


### PR DESCRIPTION
Allow only whitelisted executables files (sab itself, plus the utils explicitly installed) to remain in /app/bin. This way, we no longer need to keep track of random scriptlets that get added over time. Only executable files that sit in /app/bin are affected by the find command; not symlinks, regular files, directories, or anything in subdirs.