### PR TITLE
permit auto-updates for rust utils

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Flatpak for [SABnzbd](https://github.com/sabnzbd/sabnzbd).
 
 ## Build from source
 
-The information and commands below describe a completely manual update and build of the flatpak. In practice most of the work except for version bumps of cryptography, maturin and orjson is automated via flathub's external-data-checker, this repository's auto-update workflow, and flathub-infra's build and publish actions triggered by commits to the master branch. Unless bugs show up or the automation goes off the rails, only the manifest (org.sabnzbd.sabnzbd.yaml) and the requirements-* files occasionally need manual edits; all pypi-dependencies and cargo-sources json files are fully generated.
+The information and commands below describe a completely manual update and build of the flatpak. In practice most of the work is automated via flathub's external-data-checker, this repository's auto-update workflow, and flathub-infra's build and publish actions triggered by commits to the master branch. Unless bugs show up or the automation goes off the rails, only the manifest (org.sabnzbd.sabnzbd.yaml) and the requirements-{flatpak,orjson,cryptography}.txt files occasionally need manual edits; requirements.txt as well as all pypi-dependencies and cargo-sources json files are fully generated.
 
 ### Update the manifest and requirements files
 

--- a/org.sabnzbd.sabnzbd.yaml
+++ b/org.sabnzbd.sabnzbd.yaml
@@ -99,10 +99,10 @@ modules:
         # Remember to update the associated Cargo-*.lock and regenerate cargo-sources-*.json on every version bump!
         url: https://files.pythonhosted.org/packages/e7/b3/addd877f871fb1860d46d3a4f206ecb10b946c85846805e6367631926fd3/maturin-1.14.1.tar.gz
         sha256: 9d6577a62cd08e0ceba7a0db06fb098e0c9b1b3429bad747a4f3a18215a1b3df
-# Manual update only
-#        x-checker-data:
-#          type: pypi
-#          name: maturin
+        x-checker-data:
+          type: pypi
+          name: maturin
+          stable-only: true
 
   - name: orjson
     build-options:
@@ -121,10 +121,10 @@ modules:
         # Remember to update the associated Cargo-*.lock and regenerate cargo-sources-*.json on every version bump!
         url: https://files.pythonhosted.org/packages/7e/0c/964746fcafbd16f8ff53219ad9f6b412b34f345c75f384ad434ceaadb538/orjson-3.11.9.tar.gz
         sha256: 4fef17e1f8722c11587a6ef18e35902450221da0028e65dbaaa543619e68e48f
-# Manual update only
-#        x-checker-data:
-#          type: pypi
-#          name: orjson
+        x-checker-data:
+          type: pypi
+          name: orjson
+          stable-only: true
 
   - name: cryptography
     build-options:
@@ -143,10 +143,10 @@ modules:
         # Remember to update the associated Cargo-*.lock and regenerate cargo-sources-*.json on every version bump!
         url: https://files.pythonhosted.org/packages/1f/99/d1c90d6041656cc6ee229dc99cd67fd0cd5aec3c5f7d72fffc27cc750054/cryptography-49.0.0.tar.gz
         sha256: f89660a348f4f78a92366240a61404e337586ef7f5909a2fef59ca88ef505493
-# Manual update only
-#        x-checker-data:
-#          type: pypi
-#          name: cryptography
+        x-checker-data:
+          type: pypi
+          name: cryptography
+          stable-only: true
 
   - name: 7zip
     buildsystem: simple

--- a/pypi-dependencies-flatpak.json
+++ b/pypi-dependencies-flatpak.json
@@ -36,8 +36,8 @@
                 },
                 {
                     "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/95/2e/83be70d0379bbe17034e5d5960fae2a23cc136d466786607d2615ac2612b/vcs_versioning-2.2.3-py3-none-any.whl",
-                    "sha256": "4f7873af76f5cc24e701608354f376f5eb70b317d663787ace57a7edd7a27506"
+                    "url": "https://files.pythonhosted.org/packages/7a/26/7d2b738d2b7e177e729932dbdf1ebfa57c98846777a87a864130cc1e196b/vcs_versioning-2.2.4-py3-none-any.whl",
+                    "sha256": "48ffea8a6a175c37a718c7ee2e5f508d0e500c2cf3371791f7948bccb2b44628"
                 }
             ]
         },

--- a/pypi-dependencies-orjson.json
+++ b/pypi-dependencies-orjson.json
@@ -42,8 +42,8 @@
         },
         {
             "type": "file",
-            "url": "https://files.pythonhosted.org/packages/7d/68/d8d58938dfb1370b266a1a729e6d77a985be23689a0496498ee17b2cbf90/platformdirs-4.11.0-py3-none-any.whl",
-            "sha256": "360ccded2b7fce0af0ff80cc8f5942a1c5d99b0e856033acb030bfc634709e74"
+            "url": "https://files.pythonhosted.org/packages/4c/85/9b31b44296cfa3bb56cddb35e6a0f6578bab0b490c0806c0245e32c6110c/platformdirs-4.11.1-py3-none-any.whl",
+            "sha256": "2efd27d363e8dd2e661639ffb398865a5e0a46442a11d266bf375a0e0c10e386"
         },
         {
             "type": "file",

--- a/pypi-dependencies.json
+++ b/pypi-dependencies.json
@@ -459,8 +459,8 @@
             "sources": [
                 {
                     "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/22/d9/1728840a22a4ef8a8f479b9156aa2943cd98c3907accd3849fb0d5f82bfd/pycairo-1.29.0.tar.gz",
-                    "sha256": "f3f7fde97325cae80224c09f12564ef58d0d0f655da0e3b040f5807bd5bd3142"
+                    "url": "https://files.pythonhosted.org/packages/26/7c/ab4637b028d9ee12280ab9342f28310e613d5ca30c4d72d2aebeaa6a4969/pycairo-1.29.1.tar.gz",
+                    "sha256": "4fbd26b4af24c9787d84cf5448e34eb8dca064b732479aaecd03109520eebd5f"
                 }
             ]
         },
@@ -473,8 +473,8 @@
             "sources": [
                 {
                     "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/22/d9/1728840a22a4ef8a8f479b9156aa2943cd98c3907accd3849fb0d5f82bfd/pycairo-1.29.0.tar.gz",
-                    "sha256": "f3f7fde97325cae80224c09f12564ef58d0d0f655da0e3b040f5807bd5bd3142"
+                    "url": "https://files.pythonhosted.org/packages/26/7c/ab4637b028d9ee12280ab9342f28310e613d5ca30c4d72d2aebeaa6a4969/pycairo-1.29.1.tar.gz",
+                    "sha256": "4fbd26b4af24c9787d84cf5448e34eb8dca064b732479aaecd03109520eebd5f"
                 },
                 {
                     "type": "file",


### PR DESCRIPTION
Updates have been mostly unproblematic for a while now, might as well release the brakes on auto-updates for the rust-based utils too.